### PR TITLE
#8 Store CRUD 및 이미지 업로드 기능 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // S3
-    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.683'
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:3.3.0'
+    implementation 'software.amazon.awssdk:s3:2.20.14'
     // Resilience4j
     implementation 'io.github.resilience4j:resilience4j-spring-boot2:1.7.1'
     implementation 'io.github.resilience4j:resilience4j-bulkhead:1.7.1'

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,15 @@ dependencies {
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.683'
+    // Resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot2:1.7.1'
+    implementation 'io.github.resilience4j:resilience4j-bulkhead:1.7.1'
+    // 비동기 실행
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.awaitility:awaitility:4.3.0'
     testImplementation 'com.h2database:h2'

--- a/src/main/java/com/example/gtable/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/gtable/global/config/AsyncConfig.java
@@ -1,0 +1,21 @@
+package com.example.gtable.global.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfig {
+	@Bean(name = "s3UploadExecutor")
+	public Executor s3UploadExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(5);
+		executor.setMaxPoolSize(10);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("S3Upload-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/java/com/example/gtable/global/config/AwsS3Config.java
+++ b/src/main/java/com/example/gtable/global/config/AwsS3Config.java
@@ -1,0 +1,33 @@
+package com.example.gtable.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsS3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+
+}

--- a/src/main/java/com/example/gtable/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/gtable/global/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/oauth2/authorization/kakao", // 카카오 로그인 요청
 					"/login/oauth2/code/**", // 카카오 인증 콜백
-					"/api/refresh-token")  // refresh token (토큰 갱신)
+					"/api/refresh-token",
+					"/stores/**")  // refresh token (토큰 갱신)
 				.permitAll()
 				.anyRequest().authenticated() // 그외 요청은 허가된 사람만 인가
 			)

--- a/src/main/java/com/example/gtable/global/s3/S3Service.java
+++ b/src/main/java/com/example/gtable/global/s3/S3Service.java
@@ -1,0 +1,57 @@
+package com.example.gtable.global.s3;
+
+import java.io.InputStream;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+	private final AmazonS3Client amazonS3Client;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	public record S3UploadResult(String key, String url) {
+	}
+
+	@Bulkhead(name = "s3UploadBulkhead", type = Bulkhead.Type.THREADPOOL)
+	@Async("s3UploadExecutor")
+	public CompletableFuture<S3UploadResult> upload(Long storeId, MultipartFile file) {
+		try (InputStream inputStream = file.getInputStream()) {
+			String key = createFileKey(storeId, file.getOriginalFilename());
+			ObjectMetadata metadata = new ObjectMetadata();
+			metadata.setContentLength(file.getSize());
+
+			amazonS3Client.putObject(bucket, key, inputStream, metadata);
+			String url = amazonS3Client.getUrl(bucket, key).toString();
+
+			return CompletableFuture.completedFuture(new S3UploadResult(key, url));
+		} catch (Exception e) {
+			throw new RuntimeException("S3 업로드 실패", e);
+		}
+	}
+
+	public void delete(String filename) {
+		try {
+			amazonS3Client.deleteObject(bucket, filename);
+		} catch (Exception e) {
+			throw new RuntimeException("S3 파일 삭제 실패", e);
+		}
+	}
+
+	private String createFileKey(Long storeId, String filename) {
+		return "store/" + storeId + "/" + UUID.randomUUID() + "-" + filename;
+	}
+}

--- a/src/main/java/com/example/gtable/store/dto/StoreCreateRequest.java
+++ b/src/main/java/com/example/gtable/store/dto/StoreCreateRequest.java
@@ -23,15 +23,12 @@ public class StoreCreateRequest {
 
 	private String description;
 
-	private String storeImageUrl;
-
 	public Store toEntity() {
 		return Store.builder()
 			.departmentId(departmentId)
 			.name(name)
 			.location(location)
 			.description(description)
-			.storeImageUrl(storeImageUrl)
 			.isActive(false)
 			.deleted(false)
 			.build();

--- a/src/main/java/com/example/gtable/store/dto/StoreCreateResponse.java
+++ b/src/main/java/com/example/gtable/store/dto/StoreCreateResponse.java
@@ -18,7 +18,6 @@ public class StoreCreateResponse {
 	private String name;
 	private String location;
 	private String description;
-	private String storeImageUrl;
 	private Boolean isActive;
 	private Boolean deleted;
 	private LocalDateTime createdAt;
@@ -31,7 +30,6 @@ public class StoreCreateResponse {
 			.name(store.getName())
 			.location(store.getLocation())
 			.description(store.getDescription())
-			.storeImageUrl(store.getStoreImageUrl())
 			.isActive(store.getIsActive())
 			.deleted(store.getDeleted())
 			.build();

--- a/src/main/java/com/example/gtable/store/dto/StoreReadDto.java
+++ b/src/main/java/com/example/gtable/store/dto/StoreReadDto.java
@@ -1,8 +1,10 @@
 package com.example.gtable.store.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.example.gtable.store.model.Store;
+import com.example.gtable.storeImage.dto.StoreImageUploadResponse;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,12 +19,12 @@ public class StoreReadDto {
 	private String name;
 	private String location;
 	private String description;
-	private String storeImageUrl;
+	private List<StoreImageUploadResponse> images;
 	private Boolean isActive;
 	private Boolean deleted;
 	private LocalDateTime createdAt;
 
-	public static StoreReadDto fromEntity(Store store) {
+	public static StoreReadDto fromEntity(Store store, List<StoreImageUploadResponse> images) {
 		return StoreReadDto.builder()
 			.createdAt(store.getCreatedAt())
 			.storeId(store.getStoreId())
@@ -30,9 +32,9 @@ public class StoreReadDto {
 			.name(store.getName())
 			.location(store.getLocation())
 			.description(store.getDescription())
-			.storeImageUrl(store.getStoreImageUrl())
 			.isActive(store.getIsActive())
 			.deleted(store.getDeleted())
+			.images(images)
 			.build();
 	}
 }

--- a/src/main/java/com/example/gtable/store/dto/StoreReadResponse.java
+++ b/src/main/java/com/example/gtable/store/dto/StoreReadResponse.java
@@ -14,7 +14,7 @@ public class StoreReadResponse {
 	private List<StoreReadDto> storeReadDtos;
 	private boolean hasNext;
 
-	public static StoreReadResponse fromEntity(List<StoreReadDto> storeReadDtos, boolean hasNext) {
+	public static StoreReadResponse of(List<StoreReadDto> storeReadDtos, boolean hasNext) {
 		return StoreReadResponse.builder()
 			.storeReadDtos(storeReadDtos)
 			.hasNext(hasNext)

--- a/src/main/java/com/example/gtable/store/dto/StoreUpdateRequest.java
+++ b/src/main/java/com/example/gtable/store/dto/StoreUpdateRequest.java
@@ -13,6 +13,5 @@ public class StoreUpdateRequest {
 	private String name;
 	private String location;
 	private String description;
-	private String storeImageUrl;
 	private Boolean isActive;
 }

--- a/src/main/java/com/example/gtable/store/model/Store.java
+++ b/src/main/java/com/example/gtable/store/model/Store.java
@@ -36,8 +36,6 @@ public class Store extends BaseTimeEntity {
 
 	private String description;
 
-	private String storeImageUrl;
-
 	@Column(name = "is_active", nullable = false)
 	private Boolean isActive = false;
 
@@ -45,39 +43,32 @@ public class Store extends BaseTimeEntity {
 	private Boolean deleted = false;
 
 	public Store(LocalDateTime createdAt, Long storeId, Long departmentId, String name, String location,
-		String description, String storeImageUrl, Boolean isActive, Boolean deleted) {
+		String description, Boolean isActive, Boolean deleted) {
 		super(createdAt);
 		this.storeId = storeId;
 		this.departmentId = departmentId;
 		this.name = name;
 		this.location = location;
 		this.description = description;
-		this.storeImageUrl = storeImageUrl;
 		this.isActive = isActive;
 		this.deleted = deleted;
 	}
 
-	public void setName(String name) {
+	public void updateInfo(String name, String location, String description) {
 		this.name = name;
-	}
-
-	public void setLocation(String location) {
 		this.location = location;
-	}
-
-	public void setDescription(String description) {
 		this.description = description;
 	}
 
-	public void setStoreImageUrl(String url) {
-		this.storeImageUrl = url;
+	public void markAsDeleted() {
+		this.deleted = true;
 	}
 
-	public void setIsActive(Boolean isActive) {
-		this.isActive = isActive;
+	public void activate() {
+		this.isActive = true;
 	}
 
-	public void setDeleted(Boolean deleted) {
-		this.deleted = deleted;
+	public void deactivate() {
+		this.isActive = false;
 	}
 }

--- a/src/main/java/com/example/gtable/storeImage/controller/StoreImageController.java
+++ b/src/main/java/com/example/gtable/storeImage/controller/StoreImageController.java
@@ -1,0 +1,56 @@
+package com.example.gtable.storeImage.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.gtable.global.api.ApiUtils;
+import com.example.gtable.storeImage.dto.StoreImageUploadResponse;
+import com.example.gtable.storeImage.service.StoreImageService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/stores")
+@RequiredArgsConstructor
+public class StoreImageController {
+
+	private final StoreImageService storeImageService;
+
+	@PostMapping("/{storeId}/images")
+	public ResponseEntity<?> uploadStoreImage(
+		@PathVariable Long storeId,
+		@RequestParam("files") List<MultipartFile> files,
+		@RequestParam(value = "types") List<String> types
+	) {
+		List<StoreImageUploadResponse> response = storeImageService.saveAll(storeId, files, types);
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(
+				ApiUtils.success(
+					response
+				)
+			);
+	}
+
+	@DeleteMapping("/image/{imageId}")
+	public ResponseEntity<?> deleteStoreImage(@PathVariable Long imageId) {
+		storeImageService.delete(imageId);
+		return ResponseEntity
+			.status(HttpStatus.NO_CONTENT)
+			.body(
+				ApiUtils
+					.success(
+						"Store image deleted successfully."
+					)
+			);
+	}
+}

--- a/src/main/java/com/example/gtable/storeImage/controller/StoreImageController.java
+++ b/src/main/java/com/example/gtable/storeImage/controller/StoreImageController.java
@@ -31,6 +31,21 @@ public class StoreImageController {
 		@RequestParam("files") List<MultipartFile> files,
 		@RequestParam(value = "types") List<String> types
 	) {
+		// TODO 관련 정책 확정되면 메서드로 분리 예정
+		// 파일 개수 제한 검증
+		if (files.isEmpty() || files.size() > 10) {
+			throw new IllegalArgumentException("파일은 1개 이상 10개 이하로 업로드해 주세요.");
+		}
+		// 파일 크기 검증
+		for (MultipartFile file : files) {
+			if (file.isEmpty()) {
+				throw new IllegalArgumentException("빈 파일은 업로드할 수 없습니다.");
+			}
+			if (file.getSize() > 10 * 1024 * 1024) { // 10MB 제한
+				throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
+			}
+		}
+
 		List<StoreImageUploadResponse> response = storeImageService.saveAll(storeId, files, types);
 		return ResponseEntity
 			.status(HttpStatus.CREATED)

--- a/src/main/java/com/example/gtable/storeImage/dto/StoreImageUploadResponse.java
+++ b/src/main/java/com/example/gtable/storeImage/dto/StoreImageUploadResponse.java
@@ -1,0 +1,22 @@
+package com.example.gtable.storeImage.dto;
+
+import com.example.gtable.storeImage.model.StoreImage;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StoreImageUploadResponse {
+	private final Long id;
+	private final String imageUrl;
+	private final String type;
+
+	public static StoreImageUploadResponse fromEntity(StoreImage storeImage) {
+		return StoreImageUploadResponse.builder()
+			.id(storeImage.getId())
+			.imageUrl(storeImage.getImageUrl())
+			.type(storeImage.getType())
+			.build();
+	}
+}

--- a/src/main/java/com/example/gtable/storeImage/model/StoreImage.java
+++ b/src/main/java/com/example/gtable/storeImage/model/StoreImage.java
@@ -1,0 +1,43 @@
+package com.example.gtable.storeImage.model;
+
+import com.example.gtable.global.entity.BaseTimeEntity;
+import com.example.gtable.store.model.Store;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "store_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class StoreImage extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
+
+	@Column(nullable = false, length = 500)
+	private String imageUrl;
+
+	@Column(nullable = false, length = 500)
+	private String fileKey;
+
+	@Column(length = 20)
+	private String type;
+}

--- a/src/main/java/com/example/gtable/storeImage/repository/StoreImageRepository.java
+++ b/src/main/java/com/example/gtable/storeImage/repository/StoreImageRepository.java
@@ -1,0 +1,15 @@
+package com.example.gtable.storeImage.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.gtable.store.model.Store;
+import com.example.gtable.storeImage.model.StoreImage;
+
+@Repository
+public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
+
+	List<StoreImage> findByStore(Store store);
+}

--- a/src/main/java/com/example/gtable/storeImage/service/StoreImageService.java
+++ b/src/main/java/com/example/gtable/storeImage/service/StoreImageService.java
@@ -1,0 +1,68 @@
+package com.example.gtable.storeImage.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.gtable.global.s3.S3Service;
+import com.example.gtable.store.model.Store;
+import com.example.gtable.store.repository.StoreRepository;
+import com.example.gtable.storeImage.dto.StoreImageUploadResponse;
+import com.example.gtable.storeImage.model.StoreImage;
+import com.example.gtable.storeImage.repository.StoreImageRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StoreImageService {
+
+	private final StoreRepository storeRepository;
+	private final StoreImageRepository storeImageRepository;
+	private final S3Service s3Service;
+
+	@Transactional
+	public List<StoreImageUploadResponse> saveAll(Long storeId, List<MultipartFile> files, List<String> types) {
+		if (files.size() != types.size()) {
+			throw new IllegalArgumentException("파일과 타입의 개수가 일치해야 합니다.");
+		}
+
+		Store store = storeRepository.findById(storeId)
+			.orElseThrow(() -> new EntityNotFoundException("Store not found with id: " + storeId));
+
+		List<StoreImageUploadResponse> imageUploadResponses = new ArrayList<>();
+		for (int i = 0; i < files.size(); i++) {
+			S3Service.S3UploadResult uploadResult;
+			try {
+				uploadResult = s3Service.upload(storeId, files.get(i)).get();
+			} catch (Exception e) {
+				throw new RuntimeException("S3 업로드 실패", e);
+			}
+
+			StoreImage storeImage = StoreImage.builder()
+				.store(store)
+				.imageUrl(uploadResult.url())
+				.fileKey(uploadResult.key())
+				.type(types.get(i))
+				.build();
+
+			storeImageRepository.save(storeImage);
+			imageUploadResponses.add(StoreImageUploadResponse.fromEntity(storeImage));
+		}
+
+		return imageUploadResponses;
+	}
+
+	@Transactional
+	public void delete(Long storeImageId) {
+		StoreImage storeImage = storeImageRepository.findById(storeImageId)
+			.orElseThrow(() -> new EntityNotFoundException("StoreImage not found with id: " + storeImageId));
+
+		s3Service.delete(storeImage.getFileKey());
+		storeImageRepository.delete(storeImage);
+	}
+}


### PR DESCRIPTION
## 작업 요약
- Store CRUD 구현
- 이미지 업로드 구현
- 이미지 업로드 동시 요청 시 스레드 고갈로 인한 타임아웃 방지를 위한 Bulkhead 패턴 적용
## Issue Link
#15 #14 #8 
## 문제점 및 어려움
- Bulkhead 패턴 수치 기준값 설정 필요
- 클린코드 및 테스트 코드 추가 필요
## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 매장 이미지 업로드 및 삭제 API가 추가되었습니다. 여러 이미지를 한 번에 업로드하거나, 특정 이미지를 삭제할 수 있습니다.
    - 매장 이미지 정보를 여러 개 지원하도록 매장 조회 응답이 개선되었습니다.
    - AWS S3 연동을 통한 이미지 파일 저장 및 삭제 기능이 도입되었습니다.
    - 비동기 이미지 업로드 및 내결함성 지원을 위한 기능이 추가되었습니다.

- **기능 개선**
    - 매장 생성, 수정, 조회 시 단일 이미지 URL 대신 여러 이미지 정보를 반환하도록 변경되었습니다.
    - 매장 관련 API에서 이미지 필드 구조가 변경되었습니다.
    - 매장 정보 수정 시 이름, 위치, 설명을 한 번에 업데이트하는 방식으로 개선되었습니다.
    - 매장 활성화 및 삭제 상태 변경이 명확한 메서드 호출로 대체되었습니다.

- **버그 수정**
    - 매장 관련 요청 및 응답 객체에서 불필요한 이미지 URL 필드가 제거되었습니다.

- **보안**
    - /stores/** 경로에 대한 접근이 인증 없이 가능하도록 허용 범위가 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->