### PR TITLE
feat(signup): 관리자 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    //REDIS
+    implementation 'org.redisson:redisson-spring-boot-starter:3.19.0'
 
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.awaitility:awaitility:4.3.0'

--- a/src/main/java/com/example/gtable/global/config/RedisConfig.java
+++ b/src/main/java/com/example/gtable/global/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.example.gtable.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		return template;
+	}
+}

--- a/src/main/java/com/example/gtable/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/gtable/global/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -51,7 +53,8 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/oauth2/authorization/kakao", // 카카오 로그인 요청
 					"/login/oauth2/code/**", // 카카오 인증 콜백
-					"/api/refresh-token")  // refresh token (토큰 갱신)
+					"/api/refresh-token", // refresh token (토큰 갱신)
+					"/api/users/signup")
 				.permitAll()
 				.anyRequest().authenticated() // 그외 요청은 허가된 사람만 인가
 			)
@@ -59,6 +62,10 @@ public class SecurityConfig {
 			.addFilterBefore(new JwtAuthorizationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
+	}
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
 	}
 
 }

--- a/src/main/java/com/example/gtable/global/security/exception/ErrorMessage.java
+++ b/src/main/java/com/example/gtable/global/security/exception/ErrorMessage.java
@@ -7,14 +7,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorMessage {
 	// global
-	INVALID_INPUT_VALUE("입력값이 올바르지 않습니다.", "g001"),
+	INVALID_INPUT_VALUE("입력값이 올바르지 않습니다.", "global001"),
 
 	// auth
-	UNAUTHORIZED("권한이 없습니다", "a001"),
+	UNAUTHORIZED("권한이 없습니다", "auth001"),
 
 	// token
-	REFRESH_TOKEN_NOT_FOUND("기존 리프레시 토큰을 찾을 수 없습니다.", "t001"),
-	DOES_NOT_MATCH_REFRESH_TOKEN("기존 리프레시 토큰이 일치하지 않습니다.", "t002");
+	REFRESH_TOKEN_NOT_FOUND("기존 리프레시 토큰을 찾을 수 없습니다.", "token001"),
+	DOES_NOT_MATCH_REFRESH_TOKEN("기존 리프레시 토큰이 일치하지 않습니다.", "token002");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/example/gtable/user/controller/UserController.java
+++ b/src/main/java/com/example/gtable/user/controller/UserController.java
@@ -1,15 +1,22 @@
 package com.example.gtable.user.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.gtable.global.api.ApiUtils;
 import com.example.gtable.global.security.oauth2.dto.CustomOAuth2User;
+import com.example.gtable.user.dto.ManagerSignupRequestDto;
 import com.example.gtable.user.dto.UserResponseDto;
 import com.example.gtable.user.entity.User;
+import com.example.gtable.user.service.UserService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +26,19 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class UserController {
+    private final UserService userService;
+
+    // 관리자 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody @Valid ManagerSignupRequestDto managerSignupRequestDto) {
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(
+                ApiUtils.success(
+                    userService.signup(managerSignupRequestDto)
+                )
+            );
+    }
 
     // 로그인된 유저 정보를 확인하는 api
     @GetMapping("/me")

--- a/src/main/java/com/example/gtable/user/dto/ManagerSignupRequestDto.java
+++ b/src/main/java/com/example/gtable/user/dto/ManagerSignupRequestDto.java
@@ -1,0 +1,44 @@
+package com.example.gtable.user.dto;
+
+import com.example.gtable.user.entity.Role;
+import com.example.gtable.user.entity.SocialType;
+import com.example.gtable.user.entity.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ManagerSignupRequestDto {
+
+	@NotBlank
+	@Email(regexp = "^(?=.{1,64}@)[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)*@"
+		+ "[^-][A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z]{2,})$")
+	@Schema(description = "이메일", example = "abc@gmail.com")
+	private String email;
+
+	@NotBlank
+	@Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}")
+	@Schema(description = "비밀번호", example = "1234568!@")
+	private String password;
+
+	@NotBlank
+	@Pattern(regexp = "^[a-zA-Z가-힣]{2,12}$")
+	@Schema(description = "닉네임", example = "가십이")
+	private String nickname;
+
+	public User toEntity() {
+		return User.builder()
+			.email(email)
+			.password(password)
+			.nickname(nickname)
+			.socialType(SocialType.KAKAO)
+			.role(Role.MANAGER)
+			.build();
+
+	}
+}

--- a/src/main/java/com/example/gtable/user/dto/ManagerSignupResponseDto.java
+++ b/src/main/java/com/example/gtable/user/dto/ManagerSignupResponseDto.java
@@ -1,0 +1,35 @@
+package com.example.gtable.user.dto;
+
+import com.example.gtable.user.entity.Role;
+import com.example.gtable.user.entity.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class ManagerSignupResponseDto {
+	@Schema(description = "id", example = "1")
+	private Long id;
+	@Schema(description = "이메일", example = "abc@gmail.com")
+	private String email;
+	@Schema(description = "닉네임", example = "무한이")
+	private String nickname;
+	@Schema(description = "역할", example = "MANAGER")
+	private Role role;
+
+	public static ManagerSignupResponseDto fromEntity(User user) {
+		return ManagerSignupResponseDto.builder()
+			.id(user.getId())
+			.email(user.getEmail())
+			.nickname(user.getNickname())
+			.role(user.getRole())
+			.build();
+
+	}
+}

--- a/src/main/java/com/example/gtable/user/entity/Role.java
+++ b/src/main/java/com/example/gtable/user/entity/Role.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
     USER("USER"),
-    ADMIN("ADMIN");
+    MANAGER("MANAGER");
 
     private final String name;
 

--- a/src/main/java/com/example/gtable/user/entity/User.java
+++ b/src/main/java/com/example/gtable/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.example.gtable.user.entity;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -24,6 +26,8 @@ public class User {
     @Column(nullable = false, unique = true)
     private String email; // 카카오 이메일
 
+    private String password; // 관리자 패스워드
+
     @Column(nullable = false)
     private String nickname;
 
@@ -37,8 +41,9 @@ public class User {
     private Role role;
 
     @Builder
-    public User(String email, String nickname, String profileImage, SocialType socialType, Role role){
+    public User(String email,String password, String nickname, String profileImage, SocialType socialType, Role role){
         this.email = email;
+        this.password = password;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.socialType = socialType;
@@ -61,5 +66,8 @@ public class User {
     // User 도메인 관련 비즈니스 로직 (예: 닉네임 변경)
     public void updateNickname(String nickname){
         this.nickname = nickname;
+    }
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        password = passwordEncoder.encode(password);
     }
 }

--- a/src/main/java/com/example/gtable/user/entity/User.java
+++ b/src/main/java/com/example/gtable/user/entity/User.java
@@ -26,6 +26,7 @@ public class User {
     @Column(nullable = false, unique = true)
     private String email; // 카카오 이메일
 
+    @Column(nullable = false)
     private String password; // 관리자 패스워드
 
     @Column(nullable = false)

--- a/src/main/java/com/example/gtable/user/repository/UserRepository.java
+++ b/src/main/java/com/example/gtable/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import com.example.gtable.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByNickname(String nickName);
 }

--- a/src/main/java/com/example/gtable/user/service/UserService.java
+++ b/src/main/java/com/example/gtable/user/service/UserService.java
@@ -1,14 +1,44 @@
 package com.example.gtable.user.service;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.example.gtable.user.dto.ManagerSignupRequestDto;
+import com.example.gtable.user.dto.ManagerSignupResponseDto;
+import com.example.gtable.user.entity.User;
 import com.example.gtable.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
 
+	@Transactional
+	public ManagerSignupResponseDto signup(ManagerSignupRequestDto managerSignupRequestDto) {
+		validateEmailDuplicated(managerSignupRequestDto);
+		validateNickNameDuplicated(managerSignupRequestDto.getNickname());
+		User user = managerSignupRequestDto.toEntity();
+		user.encodePassword(passwordEncoder);
+
+		return ManagerSignupResponseDto.fromEntity(userRepository.save(user));
+
+	}
+	private void validateEmailDuplicated(ManagerSignupRequestDto managerSignupRequestDto) {
+		userRepository.findByEmail(managerSignupRequestDto.getEmail()).ifPresent(member -> {
+				throw new IllegalArgumentException();
+			}
+		);
+	}
+	private void validateNickNameDuplicated(String nickName) {
+		userRepository.findByNickname(nickName).ifPresent(member -> {
+				throw new IllegalArgumentException();
+			}
+		);
+	}
 }


### PR DESCRIPTION
## 작업 요약
signup API 구현
## Issue Link

## 문제점 및 어려움
- 패스워드 보안으로 위한 API 구현 필수(DB 내 계정 하드코딩 방지 목적)
## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 매니저 회원가입을 위한 API 엔드포인트가 추가되었습니다.
  - 매니저 회원가입 요청 및 응답을 위한 DTO가 도입되었습니다.
  - 비밀번호 암호화 및 저장 기능이 추가되었습니다.
  - 닉네임으로 사용자 조회 기능이 추가되었습니다.

- **개선 사항**
  - Redis 연동을 위한 설정이 추가되었습니다.
  - 오류 코드가 보다 명확하고 일관된 형식으로 변경되었습니다.
  - 사용자 역할(ADMIN → MANAGER) 명칭이 변경되었습니다.

- **보안**
  - 비밀번호 암호화 방식(BCrypt) 적용을 위한 설정이 추가되었습니다.
  - 회원가입 관련 엔드포인트가 인증 없이 접근 가능하도록 허용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->