### PR TITLE
feat(global): swagger 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.projectlombok:lombok'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -52,6 +51,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     //REDIS
     implementation 'org.redisson:redisson-spring-boot-starter:3.19.0'
+    // SWAGGER
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
 
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.awaitility:awaitility:4.3.0'

--- a/src/main/java/com/example/gtable/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/example/gtable/bookmark/controller/BookmarkController.java
@@ -15,14 +15,20 @@ import com.example.gtable.bookmark.service.BookmarkService;
 import com.example.gtable.global.api.ApiUtils;
 import com.example.gtable.global.security.oauth2.dto.CustomOAuth2User;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-
+@Tag(name = "Bookmark API", description = "북마크 API")
 @RestController
 @RequestMapping("/bookmarks")
 @RequiredArgsConstructor
 public class BookmarkController {
 	private final BookmarkService bookmarkService;
+
 	@PostMapping("/{storeId}")
+	@Operation(summary = "북마크 생성", description = "특정 주점에 대한 북마크 생성")
+	@ApiResponse(responseCode = "201", description = "북마크 생성")
 	public ResponseEntity<?> createBookmark(@PathVariable Long storeId,@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 		BookmarkCreateResponse response = bookmarkService.createBookmark(storeId,customOAuth2User);
 
@@ -35,6 +41,8 @@ public class BookmarkController {
 			);
 	}
 	@GetMapping
+	@Operation(summary = "북마크 조회", description = "내가 북마크한 주점 조회")
+	@ApiResponse(responseCode = "200", description = "북마크 조회")
 	public ResponseEntity<?> getAllBookmarks(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 		return ResponseEntity
 			.ok()
@@ -45,6 +53,8 @@ public class BookmarkController {
 			);
 	}
 	@DeleteMapping("/{bookmarkId}")
+	@Operation(summary = "북마크 삭제", description = "특정 주점에 대한 북마크 삭제")
+	@ApiResponse(responseCode = "200", description = "북마크 삭제")
 	public ResponseEntity<?> deleteBookmark(@PathVariable Long bookmarkId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 		return ResponseEntity
 			.ok()

--- a/src/main/java/com/example/gtable/global/config/CorsConfig.java
+++ b/src/main/java/com/example/gtable/global/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig {
 		CorsConfiguration config = new CorsConfiguration();
 
 		config.setAllowCredentials(true); // 쿠키나 인증헤더 자격증명 허용
-		config.setAllowedOrigins(List.of("http://localhost:3000")); // 허용할 출처 설정
+		config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8083")); // 허용할 출처 설정
 		config.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")); // 메서드 허용
 		config.setAllowedHeaders(List.of("*")); //클라이언트가 보낼 수 있는 헤더
 		config.setExposedHeaders(List.of("Authorization")); //클라이언트(브라우저)가 접근할 수 있는 헤더 지정

--- a/src/main/java/com/example/gtable/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/gtable/global/config/SecurityConfig.java
@@ -58,7 +58,15 @@ public class SecurityConfig {
 					"/login/oauth2/code/**", // 카카오 인증 콜백
 					"/api/refresh-token", // refresh token (토큰 갱신)
 					"/api/users/signup",
-					"/api/users/login")
+					"/api/users/login",
+					"/swagger-ui/**",
+					"/v3/api-docs/**",
+					"v3/api-docs.json",
+					"/api-docs/**",
+					"/swagger-resources/**",
+					"/webjars/**",
+					"/demo-ui.html"
+				)
 				.permitAll()
 				.anyRequest().authenticated() // 그외 요청은 허가된 사람만 인가
 			)

--- a/src/main/java/com/example/gtable/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/gtable/global/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
 					"/api/users/login",
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
-					"v3/api-docs.json",
+					"/v3/api-docs.json",
 					"/api-docs/**",
 					"/swagger-resources/**",
 					"/webjars/**",

--- a/src/main/java/com/example/gtable/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/gtable/global/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.example.gtable.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.addSecurityItem(new SecurityRequirement().addList("JWT"))
+			.components(new Components()
+				.addSecuritySchemes("JWT", new SecurityScheme()
+					.name("Authorization")
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)))
+			.info(new Info().title("NOWAIT API")
+				.description("NOWAIT API Specification")
+				.version("v0.0.1"));
+	}
+}

--- a/src/main/java/com/example/gtable/global/security/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/gtable/global/security/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import static org.springframework.http.HttpStatus.*;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.validation.FieldError;
@@ -21,6 +22,7 @@ import org.springframework.web.multipart.MultipartException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Profile("!swagger") // 또는 커스텀 조건
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 


### PR DESCRIPTION
## 작업 요약
- swaggerConfig 생성
- 의존성 추가
- security 내 swagger 접근 경로 명시
## Issue Link
#28 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - OpenAPI(스웨거) 문서화 기능이 추가되어 API 명세를 확인할 수 있습니다.
  - 스웨거 UI 및 API 문서 관련 경로가 인증 없이 접근 가능해졌습니다.
  - 북마크 API 엔드포인트에 문서화 주석이 추가되어 API 사용성이 향상되었습니다.

- **버그 수정**
  - CORS 허용 오리진에 "http://localhost:8083"이 추가되어 로컬 환경에서의 접근성이 개선되었습니다.

- **기타**
  - "swagger" 프로필 사용 시 글로벌 예외 처리기가 비활성화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->