### PR TITLE
#43 refactor endpoint

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set YML
       run: | 
         mkdir -p src/main/resources
-        echo "${{ secrets.APPLICATION_DEV_YML }}" | base64 --decode > src/main/resources/application-dev.yml
+        echo "${{ secrets.APPLICATION_DEV_YML }}" | base64 --decode > src/main/resources/application.yml
         find src
     
     - name: 프로젝트 빌드

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set YML
       run: | 
         mkdir -p src/main/resources
-        echo "${{ secrets.APPLICATION_DEV_YML }}" | base64 --decode > src/main/resources/application.yml
+        echo "${{ secrets.APPLICATION_DEV_YML }}" | base64 --decode > src/main/resources/application-dev.yml
         find src
     
     - name: 프로젝트 빌드

--- a/src/main/java/com/example/gtable/menu/controller/MenuController.java
+++ b/src/main/java/com/example/gtable/menu/controller/MenuController.java
@@ -18,7 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/menus")
+@RequestMapping("/admin/menus")
 @RequiredArgsConstructor
 public class MenuController {
 
@@ -37,7 +37,7 @@ public class MenuController {
 			);
 	}
 
-	@GetMapping("/{storeId}")
+	@GetMapping("/all-menus/stores/{storeId}")
 	public ResponseEntity<?> getMenusByStoreId(@PathVariable Long storeId) {
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/src/main/java/com/example/gtable/menuImage/controller/MenuImageController.java
+++ b/src/main/java/com/example/gtable/menuImage/controller/MenuImageController.java
@@ -17,13 +17,13 @@ import com.example.gtable.menuImage.service.MenuImageService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/menus")
+@RequestMapping("/admin/menus")
 @RequiredArgsConstructor
 public class MenuImageController {
 
 	private final MenuImageService menuImageService;
 
-	@PostMapping("/{menuId}/images")
+	@PostMapping("/images/{menuId}")
 	public ResponseEntity<?> uploadMenuImage(
 		@PathVariable Long menuId,
 		@RequestParam("file") MultipartFile file
@@ -39,9 +39,9 @@ public class MenuImageController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiUtils.success(response));
 	}
 
-	@DeleteMapping("/image/{id}")
-	public ResponseEntity<?> deleteMenuImage(@PathVariable Long id) {
-		menuImageService.delete(id);
+	@DeleteMapping("/images/{menuImageId}")
+	public ResponseEntity<?> deleteMenuImage(@PathVariable Long menuImageId) {
+		menuImageService.delete(menuImageId);
 		return ResponseEntity
 			.status(
 				HttpStatus.NO_CONTENT

--- a/src/main/java/com/example/gtable/store/controller/StoreController.java
+++ b/src/main/java/com/example/gtable/store/controller/StoreController.java
@@ -22,13 +22,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/stores")
+@RequestMapping("/admin/stores")
 @RequiredArgsConstructor
 public class StoreController {
 
 	private final StoreService storeService;
 
-	@PostMapping
+	@PostMapping("/create")
 	public ResponseEntity<?> createStore(@Valid @RequestBody StoreCreateRequest request) {
 		StoreCreateResponse response = storeService.createStore(request);
 

--- a/src/main/java/com/example/gtable/storeImage/controller/StoreImageController.java
+++ b/src/main/java/com/example/gtable/storeImage/controller/StoreImageController.java
@@ -19,13 +19,13 @@ import com.example.gtable.storeImage.service.StoreImageService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/stores")
+@RequestMapping("/admin/stores")
 @RequiredArgsConstructor
 public class StoreImageController {
 
 	private final StoreImageService storeImageService;
 
-	@PostMapping("/{storeId}/images")
+	@PostMapping("/store-images/{storeId}")
 	public ResponseEntity<?> uploadStoreImage(
 		@PathVariable Long storeId,
 		@RequestParam("files") List<MultipartFile> files,
@@ -56,9 +56,9 @@ public class StoreImageController {
 			);
 	}
 
-	@DeleteMapping("/image/{imageId}")
-	public ResponseEntity<?> deleteStoreImage(@PathVariable Long imageId) {
-		storeImageService.delete(imageId);
+	@DeleteMapping("/store-images/{storeImageId}")
+	public ResponseEntity<?> deleteStoreImage(@PathVariable Long storeImageId) {
+		storeImageService.delete(storeImageId);
 		return ResponseEntity
 			.status(HttpStatus.NO_CONTENT)
 			.body(

--- a/src/main/java/com/example/gtable/user/controller/UserController.java
+++ b/src/main/java/com/example/gtable/user/controller/UserController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 @Tag(name = "User API", description = "사용자 API")
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("admin/users")
 @RequiredArgsConstructor
 @Slf4j
 public class UserController {
@@ -46,7 +46,7 @@ public class UserController {
     }
 
     // 로그인된 유저 정보를 확인하는 api
-    @GetMapping("/me")
+    @GetMapping("/my-page")
     @Operation(summary = "내 정보 조회", description = "관리자/사용자 내정보 조회")
     @ApiResponse(responseCode = "200", description = "마이페이지에 들어갈 정보")
     public ResponseEntity<UserResponseDto> getMyInfo(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {


### PR DESCRIPTION
## 작업 요약
- 프론트 서비스와 admin 분리를 위한 request mapping path 수정
## Issue Link
#43 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - 관리자용 엔드포인트의 URL 경로가 `/admin`으로 통일되었습니다.
    - 메뉴, 매장, 사용자, 이미지 관련 API의 엔드포인트 경로가 보다 명확하고 일관성 있게 변경되었습니다.
    - 일부 엔드포인트의 경로명이 직관적으로 수정되었습니다(예: `/me` → `/my-page`, 이미지 업로드/삭제 경로 등).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->