### PR TITLE
feat(menu,order): order 중복 주문 방지

### DIFF
--- a/src/main/java/com/example/gtable/menu/controller/MenuController.java
+++ b/src/main/java/com/example/gtable/menu/controller/MenuController.java
@@ -54,4 +54,17 @@ public class MenuController {
 				)
 			);
 	}
+
+	@GetMapping("/all-menus/{menuId}")
+	@Operation(summary = "주점 메뉴 상세 조회", description = "특정 주점에 대한 메뉴 상세 조회")
+	@ApiResponse(responseCode = "200", description = "특정 주점에서 등록한 메뉴 상세 조회")
+	public ResponseEntity<?> getMenusByMenuId(@PathVariable Long menuId) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(
+				ApiUtils.success(
+					menuService. getMenusByMenuId(menuId)
+				)
+			);
+	}
 }

--- a/src/main/java/com/example/gtable/menu/service/MenuService.java
+++ b/src/main/java/com/example/gtable/menu/service/MenuService.java
@@ -49,4 +49,17 @@ public class MenuService {
 
 		return MenuReadResponse.of(menuReadRespons);
 	}
+	@Transactional(readOnly = true)
+	public Object getMenusByMenuId(Long menuId) {
+		Menu menu = menuRepository.findById(menuId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 주점에 해당 메뉴가 존재하지 않습니다."));
+
+		return MenuReadDto.builder()
+			.menuId(menuId)
+			.storeId(menu.getStoreId())
+			.name(menu.getName())
+			.description(menu.getDescription())
+			.price(menu.getPrice())
+			.build();
+	}
 }

--- a/src/main/java/com/example/gtable/menu/service/MenuService.java
+++ b/src/main/java/com/example/gtable/menu/service/MenuService.java
@@ -50,7 +50,7 @@ public class MenuService {
 		return MenuReadResponse.of(menuReadRespons);
 	}
 	@Transactional(readOnly = true)
-	public Object getMenusByMenuId(Long menuId) {
+	public MenuReadDto getMenusByMenuId(Long menuId) {
 		Menu menu = menuRepository.findById(menuId)
 			.orElseThrow(() -> new IllegalArgumentException("해당 주점에 해당 메뉴가 존재하지 않습니다."));
 

--- a/src/main/java/com/example/gtable/order/entity/UserOrder.java
+++ b/src/main/java/com/example/gtable/order/entity/UserOrder.java
@@ -1,9 +1,9 @@
 package com.example.gtable.order.entity;
 
 import com.example.gtable.global.entity.BaseTimeEntity;
-import com.example.gtable.menu.model.Menu;
 import com.example.gtable.store.model.Store;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -28,6 +28,9 @@ public class UserOrder extends BaseTimeEntity {
 	private Long id;
 
 	private Long tableId;
+
+	@Column(length = 64)
+	private String signature;
 
 	// Store와 연관관계 (N:1)
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/gtable/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/gtable/order/repository/OrderRepository.java
@@ -1,5 +1,7 @@
 package com.example.gtable.order.repository;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,6 @@ import com.example.gtable.order.entity.UserOrder;
 
 @Repository
 public interface OrderRepository extends JpaRepository<UserOrder,Long> {
+	boolean existsBySignatureAndCreatedAtAfter(String signature, LocalDateTime createdAt);
+
 }

--- a/src/main/java/com/example/gtable/orderitem/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/gtable/orderitem/repository/OrderItemRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 import com.example.gtable.orderitem.entity.OrderItem;
 
 @Repository
-public interface OrderitemRepository extends JpaRepository<OrderItem, Long> {
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 }


### PR DESCRIPTION
## 작업 요약
- menu 개별 조회로직 구현
- order 중복주문 방지 로직 구현

## Issue Link
#30 
## 문제점 및 어려움
- 시그니처 키 만으로 중복 주문을 정확히 구분할 수  없음
## 해결 방안
- 프론트 엔드에서 UUID 전달하는 방식으로 UUID가 중복되는지 확인할 것
## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 메뉴 ID로 특정 메뉴의 상세 정보를 조회할 수 있는 새로운 엔드포인트가 추가되었습니다.
    - 주문 생성 시, 동일한 주문이 2초 이내에 중복으로 접수되는 것을 방지하는 기능이 도입되었습니다.

- **버그 수정**
    - 주문 아이템 리포지토리의 이름 표기 오류가 수정되었습니다.

- **기타**
    - 주문 엔티티에 signature(시그니처) 필드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->