### PR TITLE
feat(order): 사용자별 주문 조회(세션)

### DIFF
--- a/src/main/java/com/example/gtable/menu/dto/MenuCreateRequest.java
+++ b/src/main/java/com/example/gtable/menu/dto/MenuCreateRequest.java
@@ -19,7 +19,7 @@ public class MenuCreateRequest {
 	@NotNull
 	private String description;
 	@NotNull
-	private String price;
+	private Integer price;
 
 	public Menu toEntity() {
 		return Menu.builder()

--- a/src/main/java/com/example/gtable/menu/dto/MenuCreateResponse.java
+++ b/src/main/java/com/example/gtable/menu/dto/MenuCreateResponse.java
@@ -16,7 +16,7 @@ public class MenuCreateResponse {
 	private Long storeId;
 	private String name;
 	private String description;
-	private String price;
+	private Integer price;
 	private LocalDateTime createdAt;
 
 	public static MenuCreateResponse fromEntity(Menu menu) {

--- a/src/main/java/com/example/gtable/menu/dto/MenuReadDto.java
+++ b/src/main/java/com/example/gtable/menu/dto/MenuReadDto.java
@@ -17,7 +17,7 @@ public class MenuReadDto {
 	private Long storeId;
 	private String name;
 	private String description;
-	private String price;
+	private Integer price;
 	private List<MenuImageUploadResponse> images;
 
 	public static MenuReadDto fromEntity(Menu menu, List<MenuImageUploadResponse> images) {

--- a/src/main/java/com/example/gtable/menu/model/Menu.java
+++ b/src/main/java/com/example/gtable/menu/model/Menu.java
@@ -29,9 +29,9 @@ public class Menu extends BaseTimeEntity {
 	private Long storeId;
 	private String name;
 	private String description;
-	private String price;
+	private Integer price;
 
-	public Menu(LocalDateTime createdAt, Long id, Long storeId, String name, String description, String price) {
+	public Menu(LocalDateTime createdAt, Long id, Long storeId, String name, String description, Integer price) {
 		super(createdAt);
 		this.Id = id;
 		this.storeId = storeId;

--- a/src/main/java/com/example/gtable/order/controller/OrderController.java
+++ b/src/main/java/com/example/gtable/order/controller/OrderController.java
@@ -45,16 +45,14 @@ public class OrderController {
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(
-				ApiUtils.success(
-					response
-				)
+				ApiUtils.success(response)
 			);
 	}
 
 	@GetMapping("/items/{storeId}/{tableId}")
 	@Operation(summary = "테이블별 주문 아이템 조회", description = "비로그인(세션) 기준으로 테이블의 내 주문 목록만 조회")
 	@ApiResponse(responseCode = "200", description = "주문 조회")
-	public ResponseEntity<List<OrderItemListGetResponseDto>> getOrderItems(
+	public ResponseEntity<?> getOrderItems(
 		@PathVariable Long storeId,
 		@PathVariable Long tableId,
 		HttpSession session
@@ -63,6 +61,10 @@ public class OrderController {
 		String sessionId = session.getId();
 
 		List<OrderItemListGetResponseDto> orderItems = orderService.getOrderItems(storeId, tableId, sessionId);
-		return ResponseEntity.ok(orderItems);
+		return ResponseEntity.
+			status(HttpStatus.OK)
+			.body(
+				ApiUtils.success(orderItems)
+			);
 	}
 }

--- a/src/main/java/com/example/gtable/order/controller/OrderController.java
+++ b/src/main/java/com/example/gtable/order/controller/OrderController.java
@@ -1,7 +1,10 @@
 package com.example.gtable.order.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,10 +15,12 @@ import com.example.gtable.global.api.ApiUtils;
 import com.example.gtable.order.dto.OrderCreateRequestDto;
 import com.example.gtable.order.dto.OrderCreateResponseDto;
 import com.example.gtable.order.service.OrderService;
+import com.example.gtable.orderitem.dto.OrderItemListGetResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -28,13 +33,15 @@ public class OrderController {
 
 	@PostMapping("/create/{storeId}/{tableId}")
 	@Operation(summary = "주문 생성", description = "특정 주점 - 특정 테이블에 대한 주문 생성")
-	@ApiResponse(responseCode = "201", description = "북마크 생성")
+	@ApiResponse(responseCode = "201", description = "주문 생성")
 	public ResponseEntity<?> createOrder(
 		@PathVariable Long storeId,
 		@PathVariable Long tableId,
-		@RequestBody @Valid OrderCreateRequestDto orderCreateRequestDto
+		@RequestBody @Valid OrderCreateRequestDto orderCreateRequestDto,
+		HttpSession session
 		) {
-		OrderCreateResponseDto response = orderService.createOrder(storeId,tableId,orderCreateRequestDto);
+		String sessionId = session.getId();
+		OrderCreateResponseDto response = orderService.createOrder(storeId,tableId,orderCreateRequestDto,sessionId);
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(
@@ -42,5 +49,20 @@ public class OrderController {
 					response
 				)
 			);
+	}
+
+	@GetMapping("/items/{storeId}/{tableId}")
+	@Operation(summary = "테이블별 주문 아이템 조회", description = "비로그인(세션) 기준으로 테이블의 내 주문 목록만 조회")
+	@ApiResponse(responseCode = "200", description = "주문 조회")
+	public ResponseEntity<List<OrderItemListGetResponseDto>> getOrderItems(
+		@PathVariable Long storeId,
+		@PathVariable Long tableId,
+		HttpSession session
+	) {
+		// 세션ID 추출 (Spring이 세션 자동 관리)
+		String sessionId = session.getId();
+
+		List<OrderItemListGetResponseDto> orderItems = orderService.getOrderItems(storeId, tableId, sessionId);
+		return ResponseEntity.ok(orderItems);
 	}
 }

--- a/src/main/java/com/example/gtable/order/entity/UserOrder.java
+++ b/src/main/java/com/example/gtable/order/entity/UserOrder.java
@@ -1,8 +1,13 @@
 package com.example.gtable.order.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.example.gtable.global.entity.BaseTimeEntity;
+import com.example.gtable.orderitem.entity.OrderItem;
 import com.example.gtable.store.model.Store;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,8 +16,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -21,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@SuperBuilder
+@Builder
 public class UserOrder extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,5 +43,10 @@ public class UserOrder extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "store_id")
 	private Store store;
+
+	@OneToMany(mappedBy = "userOrder", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<OrderItem> orderItems = new ArrayList<>();
+
+	private String sessionId;
 
 }

--- a/src/main/java/com/example/gtable/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/gtable/order/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.example.gtable.order.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,8 @@ import com.example.gtable.order.entity.UserOrder;
 @Repository
 public interface OrderRepository extends JpaRepository<UserOrder,Long> {
 	boolean existsBySignatureAndCreatedAtAfter(String signature, LocalDateTime createdAt);
+
+	List<UserOrder> findByStore_StoreIdAndTableIdAndSessionId(Long storeId, Long tableId, String sessionId);
+
 
 }

--- a/src/main/java/com/example/gtable/orderitem/dto/OrderItemListGetResponseDto.java
+++ b/src/main/java/com/example/gtable/orderitem/dto/OrderItemListGetResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.gtable.orderitem.dto;
+
+import com.example.gtable.orderitem.entity.OrderItem;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItemListGetResponseDto {
+	private Long orderId;
+	private String menuName;
+	private Integer quantity;
+	private Integer price;
+
+	public static OrderItemListGetResponseDto fromEntity(OrderItem orderItem) {
+		return OrderItemListGetResponseDto.builder()
+			.orderId(orderItem.getUserOrder().getId())
+			.menuName(orderItem.getMenu().getName())
+			.quantity(orderItem.getQuantity())
+			.price(orderItem.getMenu().getPrice())
+			.build();
+
+	}
+}


### PR DESCRIPTION
## 작업 요약
- 세션 기반 사용자별 주문 조회 로직 구현
- price 타입 Integer로 변경
## Issue Link
#30 
## 문제점 및 어려움
- 정확히는, 팀 단위로 주문을 구분하는 것이 아닌, 주문한 기기 단위로 구분
## 해결 방안
- 현재는 이것이 최선
- 정확히 팀단위로 구분하려면 매 주문마다 qr코드를 따로 출력해야함
## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 세션 기반 주문 생성 및 주문 항목 조회 기능이 추가되었습니다.
  - 주문 항목 목록을 반환하는 새로운 응답 형식이 도입되었습니다.

- **기능 개선**
  - 메뉴 가격 관련 필드의 자료형이 문자열에서 정수형으로 변경되어, 가격 입력 및 표시가 더욱 명확해졌습니다.

- **버그 수정**
  - 주문 생성 API 설명이 올바르게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->