### PR TITLE
feat(global,reservation):  예약crud생성 및 global 예외처리 디렉터리 구조 변경

### DIFF
--- a/src/main/java/com/example/gtable/bookmark/exception/BookmarkOwnerMismatchException.java
+++ b/src/main/java/com/example/gtable/bookmark/exception/BookmarkOwnerMismatchException.java
@@ -1,0 +1,9 @@
+package com.example.gtable.bookmark.exception;
+
+import com.example.gtable.global.exception.ErrorMessage;
+
+public class BookmarkOwnerMismatchException extends RuntimeException {
+	public BookmarkOwnerMismatchException() {
+		super(ErrorMessage.NOT_OWN_BOOKMARK.getMessage());
+	}
+}

--- a/src/main/java/com/example/gtable/bookmark/exception/DuplicateBookmarkException.java
+++ b/src/main/java/com/example/gtable/bookmark/exception/DuplicateBookmarkException.java
@@ -1,0 +1,9 @@
+package com.example.gtable.bookmark.exception;
+
+import com.example.gtable.global.exception.ErrorMessage;
+
+public class DuplicateBookmarkException extends RuntimeException {
+	public DuplicateBookmarkException() {
+		super(ErrorMessage.DUPLICATE_BOOKMARK.getMessage());
+	}
+}

--- a/src/main/java/com/example/gtable/global/exception/ErrorMessage.java
+++ b/src/main/java/com/example/gtable/global/exception/ErrorMessage.java
@@ -1,4 +1,4 @@
-package com.example.gtable.global.security.exception;
+package com.example.gtable.global.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,13 @@ public enum ErrorMessage {
 
 	// token
 	REFRESH_TOKEN_NOT_FOUND("기존 리프레시 토큰을 찾을 수 없습니다.", "token001"),
-	DOES_NOT_MATCH_REFRESH_TOKEN("기존 리프레시 토큰이 일치하지 않습니다.", "token002");
+	DOES_NOT_MATCH_REFRESH_TOKEN("기존 리프레시 토큰이 일치하지 않습니다.", "token002"),
+
+	// user
+	MISSING_USER("사용자 정보가 없습니다.", "user001"),
+	// bookmark
+	DUPLICATE_BOOKMARK("이미 북마크한 주점입니다.", "bookmark001"),
+	NOT_OWN_BOOKMARK("권한이 없습니다.", "bookmark002");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/com/example/gtable/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/gtable/global/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.example.gtable.global.security.exception;
+package com.example.gtable.global.exception;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/example/gtable/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/gtable/global/exception/GlobalExceptionHandler.java
@@ -1,13 +1,12 @@
-package com.example.gtable.global.security.exception;
+package com.example.gtable.global.exception;
 
-import static com.example.gtable.global.security.exception.ErrorMessage.*;
+import static com.example.gtable.global.exception.ErrorMessage.*;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.HttpStatus.*;
 
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.validation.FieldError;
@@ -18,6 +17,13 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MultipartException;
+
+import com.example.gtable.bookmark.exception.BookmarkOwnerMismatchException;
+import com.example.gtable.bookmark.exception.DuplicateBookmarkException;
+import com.example.gtable.global.security.exception.BusinessException;
+import com.example.gtable.global.security.exception.ResourceNotFoundException;
+import com.example.gtable.global.security.exception.UnauthorizedException;
+import com.example.gtable.user.exception.MissingUserInfoException;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.extern.slf4j.Slf4j;
@@ -91,6 +97,27 @@ public class GlobalExceptionHandler {
 	public ErrorResponse handleMultipartException(MultipartException e) {
 		log.error("handleMultipartException", e);
 		return new ErrorResponse(e.getMessage(), INVALID_INPUT_VALUE.getCode());
+	}
+
+	@ResponseStatus(value = BAD_REQUEST)
+	@ExceptionHandler(DuplicateBookmarkException.class)
+	public ErrorResponse handleDuplicateBookmarkException(DuplicateBookmarkException e) {
+		log.error("handleDuplicateBookmarkException", e);
+		return new ErrorResponse(e.getMessage(), ErrorMessage.DUPLICATE_BOOKMARK.getCode());
+	}
+
+	@ResponseStatus(value = BAD_REQUEST)
+	@ExceptionHandler(BookmarkOwnerMismatchException.class)
+	public ErrorResponse bookmarkOwnerMismatchException(BookmarkOwnerMismatchException e) {
+		log.error("bookmarkOwnerMismatchException", e);
+		return new ErrorResponse(e.getMessage(), NOT_OWN_BOOKMARK.getCode());
+	}
+
+	@ResponseStatus(value = NOT_FOUND)
+	@ExceptionHandler(IllegalStateException.class)
+	public ErrorResponse missingUserInfoException(MissingUserInfoException e) {
+		log.error("missingUserInform", e);
+		return new ErrorResponse(e.getMessage(), NOT_OWN_BOOKMARK.getCode());
 	}
 
 

--- a/src/main/java/com/example/gtable/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/gtable/global/exception/GlobalExceptionHandler.java
@@ -114,10 +114,10 @@ public class GlobalExceptionHandler {
 	}
 
 	@ResponseStatus(value = NOT_FOUND)
-	@ExceptionHandler(IllegalStateException.class)
+	@ExceptionHandler(MissingUserInfoException.class)
 	public ErrorResponse missingUserInfoException(MissingUserInfoException e) {
-		log.error("missingUserInform", e);
-		return new ErrorResponse(e.getMessage(), NOT_OWN_BOOKMARK.getCode());
+		log.error("missingUserInfoException", e);
+		return new ErrorResponse(e.getMessage(), MISSING_USER.getCode());
 	}
 
 

--- a/src/main/java/com/example/gtable/global/security/exception/BusinessException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/BusinessException.java
@@ -5,7 +5,7 @@ import com.example.gtable.global.exception.ErrorMessage;
 public abstract class BusinessException extends RuntimeException {
 	private final ErrorMessage errorMessage;
 
-	protected BusinessException(String errorMessage) {
+	protected BusinessException(ErrorMessage errorMessage) {
 		super(errorMessage.getMessage());
 		this.errorMessage = errorMessage;
 	}

--- a/src/main/java/com/example/gtable/global/security/exception/BusinessException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/BusinessException.java
@@ -1,5 +1,7 @@
 package com.example.gtable.global.security.exception;
 
+import com.example.gtable.global.exception.ErrorMessage;
+
 public abstract class BusinessException extends RuntimeException {
 	private final ErrorMessage errorMessage;
 

--- a/src/main/java/com/example/gtable/global/security/exception/BusinessException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/BusinessException.java
@@ -5,7 +5,7 @@ import com.example.gtable.global.exception.ErrorMessage;
 public abstract class BusinessException extends RuntimeException {
 	private final ErrorMessage errorMessage;
 
-	protected BusinessException(ErrorMessage errorMessage) {
+	protected BusinessException(String errorMessage) {
 		super(errorMessage.getMessage());
 		this.errorMessage = errorMessage;
 	}

--- a/src/main/java/com/example/gtable/global/security/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/RefreshTokenNotFoundException.java
@@ -5,7 +5,7 @@ import com.example.gtable.global.exception.ErrorMessage;
 public class RefreshTokenNotFoundException extends ResourceNotFoundException {
 
 	public RefreshTokenNotFoundException() {
-		super(ErrorMessage.REFRESH_TOKEN_NOT_FOUND.getMessage());
+		super(ErrorMessage.valueOf(ErrorMessage.REFRESH_TOKEN_NOT_FOUND.getMessage()));
 	}
 
 }

--- a/src/main/java/com/example/gtable/global/security/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/RefreshTokenNotFoundException.java
@@ -5,7 +5,7 @@ import com.example.gtable.global.exception.ErrorMessage;
 public class RefreshTokenNotFoundException extends ResourceNotFoundException {
 
 	public RefreshTokenNotFoundException() {
-		super(ErrorMessage.REFRESH_TOKEN_NOT_FOUND);
+		super(ErrorMessage.REFRESH_TOKEN_NOT_FOUND.getMessage());
 	}
 
 }

--- a/src/main/java/com/example/gtable/global/security/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/RefreshTokenNotFoundException.java
@@ -1,5 +1,7 @@
 package com.example.gtable.global.security.exception;
 
+import com.example.gtable.global.exception.ErrorMessage;
+
 public class RefreshTokenNotFoundException extends ResourceNotFoundException {
 
 	public RefreshTokenNotFoundException() {

--- a/src/main/java/com/example/gtable/global/security/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/ResourceNotFoundException.java
@@ -5,7 +5,7 @@ import com.example.gtable.global.exception.ErrorMessage;
 public abstract class ResourceNotFoundException extends RuntimeException {
 	private final ErrorMessage errorMessage;
 
-	protected ResourceNotFoundException(ErrorMessage errorMessage) {
+	protected ResourceNotFoundException(String errorMessage) {
 		super(errorMessage.getMessage());
 		this.errorMessage = errorMessage;
 	}

--- a/src/main/java/com/example/gtable/global/security/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/ResourceNotFoundException.java
@@ -1,5 +1,7 @@
 package com.example.gtable.global.security.exception;
 
+import com.example.gtable.global.exception.ErrorMessage;
+
 public abstract class ResourceNotFoundException extends RuntimeException {
 	private final ErrorMessage errorMessage;
 

--- a/src/main/java/com/example/gtable/global/security/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/ResourceNotFoundException.java
@@ -5,7 +5,7 @@ import com.example.gtable.global.exception.ErrorMessage;
 public abstract class ResourceNotFoundException extends RuntimeException {
 	private final ErrorMessage errorMessage;
 
-	protected ResourceNotFoundException(String errorMessage) {
+	protected ResourceNotFoundException(ErrorMessage errorMessage) {
 		super(errorMessage.getMessage());
 		this.errorMessage = errorMessage;
 	}

--- a/src/main/java/com/example/gtable/global/security/exception/TokenBadRequestException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/TokenBadRequestException.java
@@ -4,7 +4,7 @@ import com.example.gtable.global.exception.ErrorMessage;
 
 public class TokenBadRequestException extends BusinessException {
 	public TokenBadRequestException() {
-		super(ErrorMessage.DOES_NOT_MATCH_REFRESH_TOKEN);
+		super(ErrorMessage.DOES_NOT_MATCH_REFRESH_TOKEN.getMessage());
 	}
 
 }

--- a/src/main/java/com/example/gtable/global/security/exception/TokenBadRequestException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/TokenBadRequestException.java
@@ -1,5 +1,7 @@
 package com.example.gtable.global.security.exception;
 
+import com.example.gtable.global.exception.ErrorMessage;
+
 public class TokenBadRequestException extends BusinessException {
 	public TokenBadRequestException() {
 		super(ErrorMessage.DOES_NOT_MATCH_REFRESH_TOKEN);

--- a/src/main/java/com/example/gtable/global/security/exception/TokenBadRequestException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/TokenBadRequestException.java
@@ -4,7 +4,7 @@ import com.example.gtable.global.exception.ErrorMessage;
 
 public class TokenBadRequestException extends BusinessException {
 	public TokenBadRequestException() {
-		super(ErrorMessage.DOES_NOT_MATCH_REFRESH_TOKEN.getMessage());
+		super(ErrorMessage.valueOf(ErrorMessage.DOES_NOT_MATCH_REFRESH_TOKEN.getMessage()));
 	}
 
 }

--- a/src/main/java/com/example/gtable/global/security/exception/UnauthorizedException.java
+++ b/src/main/java/com/example/gtable/global/security/exception/UnauthorizedException.java
@@ -1,5 +1,7 @@
 package com.example.gtable.global.security.exception;
 
+import com.example.gtable.global.exception.ErrorMessage;
+
 public class UnauthorizedException extends RuntimeException {
 	private final ErrorMessage errorMessage;
 

--- a/src/main/java/com/example/gtable/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/gtable/reservation/controller/ReservationController.java
@@ -1,0 +1,75 @@
+package com.example.gtable.reservation.controller;
+
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.gtable.global.api.ApiUtils;
+import com.example.gtable.global.security.oauth2.dto.CustomOAuth2User;
+import com.example.gtable.reservation.dto.ReservationCreateRequestDto;
+import com.example.gtable.reservation.dto.ReservationCreateResponseDto;
+import com.example.gtable.reservation.dto.ReservationGetResponseDto;
+import com.example.gtable.reservation.service.ReservationService;
+@Tag(name = "Reservation API", description = "예약 API")
+@RestController
+@RequestMapping("/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+	private final ReservationService reservationService;
+
+	@PostMapping("/create/{storeId}")
+	@Operation(summary = "예약 생성", description = "특정 주점에 대한 예약하기 생성")
+	@ApiResponse(responseCode = "201", description = "예약 생성")
+	public ResponseEntity<?> create(
+		@PathVariable Long storeId,
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+		@RequestBody ReservationCreateRequestDto requestDto) {
+		ReservationCreateResponseDto response = reservationService.create(storeId, customOAuth2User, requestDto);
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(
+				ApiUtils.success(
+					response
+				)
+			);
+	}
+
+	@GetMapping("/admin/{storeId}")
+	@Operation(summary = "주점별 예약리스트 조회", description = "특정 주점에 대한 예약리스트 조회")
+	@ApiResponse(responseCode = "200", description = "예약리스트 조회")
+	public ResponseEntity<?> getReservationListByStoreId(@PathVariable Long storeId) {
+		List<ReservationGetResponseDto> response = reservationService.getReservationListByStoreId(storeId);
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(
+				ApiUtils.success(
+					response
+				)
+			);
+	}
+
+	// @PatchMapping("/{id}/status")
+	// public ReservationDto.Response updateStatus(
+	// 	@PathVariable Long id,
+	// 	@RequestParam Reservation.Status status
+	// ) {
+	// 	return reservationService.updateStatus(id, status);
+	// }
+	//
+	// @DeleteMapping("/{id}")
+	// public void delete(@PathVariable Long id) {
+	// 	reservationService.delete(id);
+	// }
+
+
+}

--- a/src/main/java/com/example/gtable/reservation/dto/ReservationCreateRequestDto.java
+++ b/src/main/java/com/example/gtable/reservation/dto/ReservationCreateRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.gtable.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationCreateRequestDto {
+	private Integer partySize;
+}

--- a/src/main/java/com/example/gtable/reservation/dto/ReservationCreateResponseDto.java
+++ b/src/main/java/com/example/gtable/reservation/dto/ReservationCreateResponseDto.java
@@ -12,4 +12,5 @@ public class ReservationCreateResponseDto {
 	private Long userId;
 	private LocalDateTime requestedAt;
 	private String status;
+	private Integer partySize;
 }

--- a/src/main/java/com/example/gtable/reservation/dto/ReservationCreateResponseDto.java
+++ b/src/main/java/com/example/gtable/reservation/dto/ReservationCreateResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.gtable.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReservationCreateResponseDto {
+	private Long id;
+	private Long storeId;
+	private Long userId;
+	private LocalDateTime requestedAt;
+	private String status;
+}

--- a/src/main/java/com/example/gtable/reservation/dto/ReservationGetResponseDto.java
+++ b/src/main/java/com/example/gtable/reservation/dto/ReservationGetResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.gtable.reservation.dto;
+
+import java.time.LocalDateTime;
+
+import com.example.gtable.bookmark.dto.BookmarkGetResponse;
+import com.example.gtable.bookmark.entity.Bookmark;
+import com.example.gtable.reservation.entity.Reservation;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationGetResponseDto {
+	private Long id;
+	private Long storeId;
+	private String userName;
+	private LocalDateTime requestedAt;
+	private String status;
+	private Integer partySize;
+
+	public static ReservationGetResponseDto fromEntity(Reservation reservation) {
+		return ReservationGetResponseDto.builder()
+			.id(reservation.getId())
+			.storeId(reservation.getStore().getStoreId())
+			.userName(reservation.getUser().getNickname())
+			.requestedAt(reservation.getRequestedAt())
+			.status(reservation.getStatus().name())
+			.partySize(reservation.getPartySize())
+			.build();
+	}
+}

--- a/src/main/java/com/example/gtable/reservation/entity/Reservation.java
+++ b/src/main/java/com/example/gtable/reservation/entity/Reservation.java
@@ -1,0 +1,39 @@
+package com.example.gtable.reservation.entity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+import com.example.gtable.store.model.Store;
+import com.example.gtable.user.entity.User;
+
+@Entity
+@Table(name = "waiting_requests")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Reservation {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "store_id")
+	private Store store;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Column(name = "requested_at", nullable = false)
+	private LocalDateTime requestedAt;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ReservationStatus status;
+
+	@Column(name = "partysize", nullable = false)
+	private Integer partySize;
+
+}

--- a/src/main/java/com/example/gtable/reservation/entity/Reservation.java
+++ b/src/main/java/com/example/gtable/reservation/entity/Reservation.java
@@ -33,7 +33,7 @@ public class Reservation {
 	@Column(nullable = false)
 	private ReservationStatus status;
 
-	@Column(name = "partysize", nullable = false)
+	@Column(name = "party_size", nullable = false)
 	private Integer partySize;
 
 }

--- a/src/main/java/com/example/gtable/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/example/gtable/reservation/entity/ReservationStatus.java
@@ -1,0 +1,5 @@
+package com.example.gtable.reservation.entity;
+
+public enum ReservationStatus {
+	WAITING,CALLING, CONFIRMED, CANCELLED
+}

--- a/src/main/java/com/example/gtable/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/example/gtable/reservation/repository/ReservationRepository.java
@@ -1,0 +1,11 @@
+package com.example.gtable.reservation.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.gtable.reservation.entity.Reservation;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+	List<Reservation> findAllByStore_StoreId(Long storeId);
+}

--- a/src/main/java/com/example/gtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/gtable/reservation/service/ReservationService.java
@@ -1,0 +1,67 @@
+package com.example.gtable.reservation.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.gtable.global.security.oauth2.dto.CustomOAuth2User;
+import com.example.gtable.reservation.dto.ReservationCreateRequestDto;
+import com.example.gtable.reservation.dto.ReservationCreateResponseDto;
+import com.example.gtable.reservation.dto.ReservationGetResponseDto;
+import com.example.gtable.reservation.entity.Reservation;
+import com.example.gtable.reservation.entity.ReservationStatus;
+import com.example.gtable.reservation.repository.ReservationRepository;
+import com.example.gtable.store.model.Store;
+import com.example.gtable.store.repository.StoreRepository;
+import com.example.gtable.user.entity.User;
+import com.example.gtable.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+	private final ReservationRepository reservationRepository;
+	private final StoreRepository storeRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public ReservationCreateResponseDto create(Long storeId, CustomOAuth2User customOAuth2User,
+		ReservationCreateRequestDto requestDto) {
+		Store store = storeRepository.findById(storeId)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 store"));
+		User user = userRepository.findById(customOAuth2User.getUserId())
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 user"));
+
+		Reservation reservation = Reservation.builder()
+			.store(store)
+			.user(user)
+			.requestedAt(LocalDateTime.now())
+			.status(ReservationStatus.WAITING)
+			.build();
+
+		Reservation saved = reservationRepository.save(reservation);
+
+		return ReservationCreateResponseDto.builder()
+			.id(saved.getId())
+			.storeId(saved.getStore().getStoreId())
+			.userId(saved.getUser().getId())
+			.requestedAt(saved.getRequestedAt())
+			.status(saved.getStatus().name())
+			.build();
+	}
+	@Transactional(readOnly = true)
+	public List<ReservationGetResponseDto> getReservationListByStoreId(Long storeId) {
+		List<Reservation> reservations = reservationRepository.findAllByStore_StoreId(storeId);
+
+		return reservations.stream()
+			.map(ReservationGetResponseDto::fromEntity)
+			.toList();
+	}
+
+	// 나머지 메서드도 동일하게 store/user 접근 시 getId() 활용
+}
+

--- a/src/main/java/com/example/gtable/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/gtable/reservation/service/ReservationService.java
@@ -51,6 +51,7 @@ public class ReservationService {
 			.userId(saved.getUser().getId())
 			.requestedAt(saved.getRequestedAt())
 			.status(saved.getStatus().name())
+			.partySize(saved.getPartySize())
 			.build();
 	}
 	@Transactional(readOnly = true)

--- a/src/main/java/com/example/gtable/user/dto/ManagerSignupRequestDto.java
+++ b/src/main/java/com/example/gtable/user/dto/ManagerSignupRequestDto.java
@@ -36,7 +36,7 @@ public class ManagerSignupRequestDto {
 			.email(email)
 			.password(password)
 			.nickname(nickname)
-			.socialType(SocialType.KAKAO)
+			.socialType(SocialType.LOCAL)
 			.role(Role.MANAGER)
 			.build();
 

--- a/src/main/java/com/example/gtable/user/entity/SocialType.java
+++ b/src/main/java/com/example/gtable/user/entity/SocialType.java
@@ -1,5 +1,5 @@
 package com.example.gtable.user.entity;
 
 public enum SocialType {
-    KAKAO, NAVER, GOOGLE
+    KAKAO,LOCAL
 }

--- a/src/main/java/com/example/gtable/user/exception/MissingUserInfoException.java
+++ b/src/main/java/com/example/gtable/user/exception/MissingUserInfoException.java
@@ -1,0 +1,9 @@
+package com.example.gtable.user.exception;
+
+import com.example.gtable.global.exception.ErrorMessage;
+
+public class MissingUserInfoException extends RuntimeException {
+	public MissingUserInfoException() {
+		super(ErrorMessage.MISSING_USER.getMessage());
+	}
+}


### PR DESCRIPTION
## 작업 요약
- reservation 도메인 생성
- global예외핸들러 디렉터리 구조조정
- 북마크 커스텀 예외 생성
## Issue Link
#55 
## 문제점 및 어려움

## 해결 방안

## Reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 예약 생성 및 예약 목록 조회를 위한 예약 컨트롤러가 추가되었습니다.
  - 예약 관련 요청 및 응답을 위한 DTO 클래스가 도입되었습니다.
  - 예약 엔티티, 상태(enum), 저장소, 서비스가 새롭게 추가되어 예약 관리가 가능합니다.
  - 북마크 및 사용자 정보 관련 새로운 예외 클래스가 추가되었습니다.

- **버그 수정**
  - 사용자 회원가입 시 소셜 타입이 LOCAL로 변경되었습니다.

- **개선 사항**
  - 예약, 북마크, 사용자 정보 관련 오류에 대해 더 구체적인 예외 및 에러 메시지가 제공됩니다.
  - 글로벌 예외 처리기가 예약 및 북마크 관련 예외를 세분화하여 처리하도록 확장되었습니다.
  - 지원하는 소셜 타입이 KAKAO와 LOCAL로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->